### PR TITLE
Fix stretched animated statics

### DIFF
--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -815,7 +815,8 @@ public class MapManager
             _animatedStaticsManager.Process(gameTime);
             foreach (var animatedStaticTile in AnimatedStaticTiles)
             {
-                animatedStaticTile.UpdateId();
+              animatedStaticTile.UpdateId();
+              animatedStaticTile.Update();
             }
         }
         foreach (var landObject in _ToRecalculate)

--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -815,8 +815,8 @@ public class MapManager
             _animatedStaticsManager.Process(gameTime);
             foreach (var animatedStaticTile in AnimatedStaticTiles)
             {
-              animatedStaticTile.UpdateId();
-              animatedStaticTile.Update();
+                animatedStaticTile.UpdateId();
+                animatedStaticTile.Update();
             }
         }
         foreach (var landObject in _ToRecalculate)


### PR DESCRIPTION
###  Problem
Animated static tiles were rendered stretched to the size of the first frame because the per‑frame Update() call was never executed after UpdateId(). 

### Solution
Invoke animatedStaticTile.Update() inside MapManager.Update() right after animatedStaticTile.UpdateId() (1‑line change). 

#### Before
![before](https://github.com/user-attachments/assets/4cce05c6-3583-46aa-a053-82ca87975197)

#### After
![after](https://github.com/user-attachments/assets/867bf7ca-d28b-4eab-93be-d161af173eee)